### PR TITLE
Fix missing category helper and optional course fields

### DIFF
--- a/src/components/ui/CourseCard.tsx
+++ b/src/components/ui/CourseCard.tsx
@@ -10,7 +10,7 @@ interface CourseCardProps {
 }
 
 const CourseCard: React.FC<CourseCardProps> = ({ course }) => {
-  const categoryName = getCategoryName(course.category);
+  const categoryName = course.category ? getCategoryName(course.category) : null;
   
   return (
     <Link 
@@ -26,18 +26,24 @@ const CourseCard: React.FC<CourseCardProps> = ({ course }) => {
           <h3 className="text-[16px] font-medium text-[#1F1F1F] mb-1">{course.title}</h3>
           
           <div className="flex flex-wrap gap-2 mt-2">
-            <span className="inline-flex items-center px-2 py-1 rounded-md text-xs font-medium bg-[#F8F7F4] text-[#728775]">
-              {categoryName}
-            </span>
-            
-            <span className="inline-flex items-center px-2 py-1 rounded-md text-xs font-medium bg-[#F8F7F4] text-[#728775]">
-              {course.level}-level
-            </span>
-            
-            <span className="inline-flex items-center px-2 py-1 rounded-md text-xs font-medium bg-[#F8F7F4] text-[#728775]">
-              Semester {course.semester}
-            </span>
-            
+            {categoryName && (
+              <span className="inline-flex items-center px-2 py-1 rounded-md text-xs font-medium bg-[#F8F7F4] text-[#728775]">
+                {categoryName}
+              </span>
+            )}
+
+            {course.level && (
+              <span className="inline-flex items-center px-2 py-1 rounded-md text-xs font-medium bg-[#F8F7F4] text-[#728775]">
+                {course.level}-level
+              </span>
+            )}
+
+            {course.semester && (
+              <span className="inline-flex items-center px-2 py-1 rounded-md text-xs font-medium bg-[#F8F7F4] text-[#728775]">
+                Semester {course.semester}
+              </span>
+            )}
+
             {course.is_intensive && (
               <span className="inline-flex items-center px-2 py-1 rounded-md text-xs font-medium bg-[#F8F7F4] text-[#728775]">
                 Intensive

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -33,6 +33,11 @@ export type Course = {
   created_at?: string | null;
   subfield?: Subfield;
   offered_in?: string;
+  /** Old catalogue fields kept for compatibility */
+  level?: number;
+  category?: string;
+  semester?: number;
+  is_intensive?: boolean;
 };
 
 export const fetchMajors = async (): Promise<Major[]> => {
@@ -156,4 +161,17 @@ export const formatSemesterCode = (code: string | null | undefined): string => {
   };
   
   return semesterMap[code] || code;
+};
+
+export const getCategoryName = (code: string | null | undefined): string => {
+  if (!code) return 'Unknown';
+
+  const categoryMap: Record<string, string> = {
+    ACC: 'Academic Core',
+    SCI: 'Sciences',
+    SSC: 'Social Sciences',
+    HUM: 'Humanities'
+  };
+
+  return categoryMap[code] || code;
 };


### PR DESCRIPTION
## Summary
- include optional fields in Course type
- add `getCategoryName` helper to map catalog codes
- guard CourseCard labels when fields are missing

## Testing
- `npx tsc -p tsconfig.app.json` *(fails: Cannot find module 'react')*
- `npm run build` *(fails: vite not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68416bec764c8325a141f9aece859595