### PR TITLE
Add course filter bar

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,17 +1,16 @@
 import React, { useState, useEffect } from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { Book, Menu, X, Search } from 'lucide-react';
+import { Book, Menu, X } from 'lucide-react';
 
 const Header: React.FC = () => {
-  const [isScrolled, setIsScrolled] = useState(false);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const location = useLocation();
 
   useEffect(() => {
     const handleScroll = () => {
-      setIsScrolled(window.scrollY > 10);
+      // noop for now, reserved for future scroll effects
     };
-    
+
     window.addEventListener('scroll', handleScroll);
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);

--- a/src/components/ui/CourseFilterBar.tsx
+++ b/src/components/ui/CourseFilterBar.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+interface CourseFilterBarProps {
+  semester: string;
+  level: string;
+  onSemesterChange: (value: string) => void;
+  onLevelChange: (value: string) => void;
+  className?: string;
+}
+
+const CourseFilterBar: React.FC<CourseFilterBarProps> = ({
+  semester,
+  level,
+  onSemesterChange,
+  onLevelChange,
+  className = '',
+}) => {
+  return (
+    <div className={`flex gap-4 ${className}`}>
+      <select
+        value={semester}
+        onChange={e => onSemesterChange(e.target.value)}
+        className="h-[40px] px-3 rounded-md border border-[#E8E7E4] bg-white text-[#1F1F1F] focus:outline-none"
+      >
+        <option value="all">All Semesters</option>
+        <option value="Semester 1">Semester 1</option>
+        <option value="January Intensive">January Intensive</option>
+        <option value="Semester 2">Semester 2</option>
+        <option value="June Intensive">June Intensive</option>
+      </select>
+      <select
+        value={level}
+        onChange={e => onLevelChange(e.target.value)}
+        className="h-[40px] px-3 rounded-md border border-[#E8E7E4] bg-white text-[#1F1F1F] focus:outline-none"
+      >
+        <option value="all">All Levels</option>
+        <option value="100">100</option>
+        <option value="200">200</option>
+        <option value="300">300</option>
+      </select>
+    </div>
+  );
+};
+
+export default CourseFilterBar;

--- a/src/components/ui/CourseList.tsx
+++ b/src/components/ui/CourseList.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { Book, Tag, Calendar } from 'lucide-react';
+import { Book } from 'lucide-react';
 import type { Course } from '../../lib/supabase';
 
 interface CourseListProps {

--- a/src/components/ui/SubfieldCard.tsx
+++ b/src/components/ui/SubfieldCard.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { BookOpen } from 'lucide-react';
 import type { Subfield } from '../../lib/supabase';
 
 interface SubfieldCardProps {

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -55,7 +55,7 @@ export const fetchMajors = async (): Promise<Major[]> => {
 };
 
 export const fetchSubfields = async (majorSlug: string): Promise<Subfield[]> => {
-  let query = supabase
+  const query = supabase
     .from('subfields')
     .select('*, majors!inner(*)')
     .eq('majors.slug', majorSlug);

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { MessageSquare } from 'lucide-react';
 import SearchBar from '../components/ui/SearchBar';
 import Button from '../components/ui/Button';
 import CategoryCard from '../components/ui/CategoryCard';
@@ -72,7 +71,7 @@ const HomePage: React.FC = () => {
       <section className="bg-[#F8F7F4] pb-16">
         <div className="max-w-[1100px] mx-auto px-6">
           <div className="flex gap-4 overflow-x-auto pb-4 snap-x">
-            {categories.map((category, index) => (
+            {categories.map(category => (
               <CategoryCard 
                 key={category.title}
                 title={category.title} 


### PR DESCRIPTION
## Summary
- add `CourseFilterBar` component for selecting semester and course level
- filter courses in `CoursesPage` based on search, semester and level
- clean up unused imports across the repo

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68416f26581c8325b53f0bb5414a6dea